### PR TITLE
Change minimal body and chassis length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - Minimal valid length of chassis_code and body_code is 8 symbols
-- Minimal `avto-dev/extended-laravel-validator` version now is `4.0`
 - Minimal `avto-dev/identity-laravel` version now is `5.9`
+- Minimal `avto-dev/extended-laravel-validator` version now is `4.0`
 
 ## v3.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Minimal valid length of chassis_code and body_code is 8 symbols
+- Minimal `avto-dev/extended-laravel-validator` version now is `4.0`
+- Minimal `avto-dev/identity-laravel` version now is `5.9`
+
 ## v3.7.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "fakerphp/faker": "^1.23.1"
     },
     "require-dev": {
-        "avto-dev/extended-laravel-validator": "^3.7",
-        "avto-dev/identity-laravel": "^5.7",
+        "avto-dev/extended-laravel-validator": "^4.0",
+        "avto-dev/identity-laravel": "^5.9",
         "laravel/laravel": "~10.0 || ~11.0",
         "phpstan/phpstan": "^1.10.66",
         "phpunit/phpunit": "^10.5"

--- a/src/Providers/Identifiers/BodyProvider.php
+++ b/src/Providers/Identifiers/BodyProvider.php
@@ -32,7 +32,7 @@ class BodyProvider extends AbstractIdentifierProvider
      * @var string[]
      */
     protected static $formats = [
-        '#######',
+        '########',
         '??##########',
         '???###-#######',
         '???### #######',
@@ -81,7 +81,7 @@ class BodyProvider extends AbstractIdentifierProvider
                 break;
 
             case 1:
-                $code = \mb_substr($this->bodyCode(...$arguments), 0, 6);
+                $code = \mb_substr($this->bodyCode(...$arguments), 0, 7);
                 break;
         }
 


### PR DESCRIPTION
## Description

### Changed

- Minimal valid length of chassis_code and body_code is 8 symbols
- Minimal `avto-dev/extended-laravel-validator` version now is `4.0`
- Minimal `avto-dev/identity-laravel` version now is `5.9`
