### PR TITLE
The `fakerphp/faker` package bumped to `^1.24.0` to be compatible with PHP 8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Версия пакета `fakerphp/faker` поднята до `^1.24.0` совместимой с PHP 8.4
+
 ## v3.9.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Changed
 
-- Версия пакета `fakerphp/faker` поднята до `^1.24.0` совместимой с PHP 8.4
+- `fakerphp/faker` package bumped to `^1.24.0` to be compatible with PHP 8.4
 
 ## v3.9.0
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^8.1",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "fakerphp/faker": "^1.23.1"
+        "fakerphp/faker": "^1.24.0"
     },
     "require-dev": {
         "avto-dev/extended-laravel-validator": "^5.0",


### PR DESCRIPTION


## Description

The `fakerphp/faker` package version has been bumped to `^1.24.0` to be compatible with PHP 8.4

`1.24.0` -- is a minimal `fakerphp/faker` package version compatible with PHP 8.4 https://github.com/FakerPHP/Faker/releases/tag/v1.24.0

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
